### PR TITLE
Reading of Sensors appear to stop

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.associations": {
+    "functional": "cpp"
+  }
+}

--- a/src/ha_config.h
+++ b/src/ha_config.h
@@ -6,7 +6,8 @@
 
 #define SERIAL_BAUD_RATE 115200
 
-#define ANALOG_SUPPLY_VOLTAGE 5.0
+#define ANALOG_SUPPLY_VOLTAGE 5.0 // The voltage supplied to the analog sensors (pH, EC, DO, ORP)
+#define ADC_RANGE 1024.0
 #define BROKER_ADDR IPAddress(192, 168, 68, 122)
 
 #define MQTT_SENSOR_COUNT 20
@@ -45,6 +46,7 @@ Sensor pin settings
 #define KVALUEADDR 0x0A    //the start address of the K value stored in the EEPROM
 #define ECRES2 820.0
 #define ECREF 200.0
+#define DEFAULT_ORP_OFFSET_MV 0 // The default offset value for the ORP sensor
 
 #define DEBUG_PRINT_ENABLED // Comment out this line of code if you don't want to see the debug print
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -173,7 +173,7 @@ double getValueTemperatureSensor()
   DEBUG_PRINT("tempRead: ");
   DEBUG_PRINTLN(tempRead);
   float TemperatureSum = tempRead / 16;
-  DEBUG_PRINT("Temp V alue: ");
+  DEBUG_PRINT("Temp Value: ");
   DEBUG_PRINTLN(TemperatureSum);
   return TemperatureSum;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -173,7 +173,8 @@ double getValueTemperatureSensor()
   DEBUG_PRINT("tempRead: ");
   DEBUG_PRINTLN(tempRead);
   float TemperatureSum = tempRead / 16;
-
+  DEBUG_PRINT("Temp V alue: ");
+  DEBUG_PRINTLN(TemperatureSum);
   return TemperatureSum;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -510,12 +510,9 @@ void loop()
       // set tankLevelSensor value
       int levelReading = digitalRead(LEVELPIN);
       tnakLevelSensor.setState(levelReading);
-    }
+    } // end if readCount > INITIAL_READER_COUNTER
     // reset loop timer
     lastUpdateAt = millis();
-  }
+  }// end if ((millis() - lastUpdateAt) > THRESHOLD)
 
-  // You can also change the state at runtime as shown below.
-  // This kind of logic can be used if you want to control your light using a button connected to the device.
-  // light.setState(true); // use any state you want
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -125,8 +125,7 @@ double getTDSValue(float temperature)
  */
 double getValueTemperatureSensor()
 {
-  DEBUG_PRINTLN("==> getValueTemperatureSensor");
-  // returns the temperature from one DS18S20 in DEG Celsius
+  DEBUG_PRINTLN("==> getValueTemperatureSensor: ");
 
   byte data[12];
   byte addr[8];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -360,7 +360,6 @@ void setup()
   Serial.println("Starting setup...");
   Serial.println("DNS and DHCP-based web client test 2024-02-29"); // so I can keep track of what is loaded start the Ethernet connection:connect to wifi
 
-
   // ==================== Setup Action Pins ====================
   // WiFi.config(ip, gateway, subnet);
   WiFi.begin(ssid, pass);
@@ -472,9 +471,9 @@ void loop()
   mqtt.loop();
   /**
    * @brief This is the time in milliseconds since the last time the sensors were updated.
-  */
+   */
   if ((millis() - lastUpdateAt) > THRESHOLD)
-  { 
+  {
     /**
      * @brief Represents the uptime value in seconds.
      */
@@ -484,7 +483,7 @@ void loop()
     DEBUG_PRINTLN(readCount);
     uptimeSensor.setValue(uptimeValue);
     // ignore the imitial readings as it takes time for the sensors to stabilize
-    if (readCount > INITIAL_READER_COUNTER )
+    if (readCount > INITIAL_READER_COUNTER)
     {
       DEBUG_PRINTLN("Updating sensor value for orbSensor");
       // set orbSensor value
@@ -510,9 +509,8 @@ void loop()
       // set tankLevelSensor value
       int levelReading = digitalRead(LEVELPIN);
       tnakLevelSensor.setState(levelReading);
+      // reset loop timer
+      lastUpdateAt = millis();
     } // end if readCount > INITIAL_READER_COUNTER
-    // reset loop timer
-    lastUpdateAt = millis();
-  }// end if ((millis() - lastUpdateAt) > THRESHOLD)
-
+  } // end if ((millis() - lastUpdateAt) > THRESHOLD)
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -170,11 +170,9 @@ double getValueTemperatureSensor()
   byte LSB = data[0];
 
   float tempRead = ((MSB << 8) | LSB); // using two's compliment
-  DEBUG_PRINT("tempRead: ");
-  DEBUG_PRINTLN(tempRead);
+  //DEBUG_PRINT("tempRead: ");
+  //DEBUG_PRINTLN(tempRead);
   float TemperatureSum = tempRead / 16;
-  DEBUG_PRINT("Temp Value: ");
-  DEBUG_PRINTLN(TemperatureSum);
   return TemperatureSum;
 }
 
@@ -486,14 +484,15 @@ void loop()
     // ignore the imitial readings as it takes time for the sensors to stabilize
     if (readCount > INITIAL_READER_COUNTER)
     {
+      //DEBUG_PRINT("Updating sensor value for temperature: ");
+      // set temperature value
+      float tempReading = getValueTemperatureSensor();
+      temperature.setValue(tempReading);
+      DEBUG_PRINT(tempReading);
       DEBUG_PRINTLN("Updating sensor value for orbSensor");
       // set orbSensor value
       uint16_t reading = analogRead(ORPPIN);
       orbSensor.setValue(reading);
-      DEBUG_PRINTLN("Updating sensor value for temperature");
-      // set temperature value
-      float tempReading = getValueTemperatureSensor();
-      temperature.setValue(tempReading);
       DEBUG_PRINTLN("Updating sensor value for phSensor");
       // set phSensor values
       float phReading = getValuePHSensor(tempReading);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -311,7 +311,11 @@ double getValuePHSensor(float temperature)
 double getOrbSensorValue()
 {
   double orbReading = analogRead(ORPPIN);
-  double orpValue = ((30 * (double) SYSTEM_VOLTAGE * 1000) - (75 * SYSTEM_VOLTAGE * 1000 / 1024)) / 75;
+  DEBUG_PRINT("  RAW OrbReading: ");
+  DEBUG_PRINT(orbReading);
+  DEBUG_PRINT("  ");
+  // ANALOG_SUPPLY_VOLTAGE * 1000 to get mv
+  double orpValue = ((30 * (ANALOG_SUPPLY_VOLTAGE * 1000)) - (75 * orbReading * (ANALOG_SUPPLY_VOLTAGE * 1000) / 1024)) / 75- DEFAULT_ORP_OFFSET_MV;
   return orpValue;
 }
 


### PR DESCRIPTION
The sensors:
- ORB
- Temperature
- pH
- TDS
- EC
- Level
Are supposed to be read every 2,000 milliseconds.

``` c++
((millis() - lastUpdateAt) > THRESHOLD)
```

Where 
- THRESHOLD=2,000
- unsigned long lastUpdateAt - is set in loop
- millis() is the 

When Imonitor MQTT with a broker it appears that they are not read at all?

The expression (millis() - lastUpdateAt) > THRESHOLD in Arduino code typically won't overflow itself, even if millis() overflows. Here's why:

Overflow of millis(): millis() is an unsigned long variable, which on most Arduino boards has a maximum value of 4,294,967,295 milliseconds (approximately 50 days). After reaching this limit, it wraps around to zero and starts counting again.

Subtraction handling overflow: In your code, even if millis() overflows and becomes zero, the subtraction (millis() - lastUpdateAt) usually won't cause an overflow because it considers the relative difference between the two values.

Here's a breakdown of why overflow is avoided:

Assuming overflow: Let's say millis() overflows to zero, and lastUpdateAt has a previous high value (close to the maximum).
Subtraction: When you subtract the new millis() (zero) from lastUpdateAt, the result will be a large positive number because lastUpdateAt was much bigger.
Comparison: This large positive number is then compared to THRESHOLD. As long as THRESHOLD is a reasonable value (less than the maximum millis() value), the condition (millis() - lastUpdateAt) > THRESHOLD will still evaluate correctly.

It appears the loop

``` c++
if ((millis() - lastUpdateAt) > THRESHOLD)
{
  ....various code here....
    // reset loop timer
    lastUpdateAt = millis();
}
```
stops executing the code inside the loop.
